### PR TITLE
fixing missing 'e' to the libapache2-mod-wsgi-py3 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To deploy this web application, create a basic server using a VPS / cloud provid
 
 The following services need to be installed on cloud host, use your favorite package manager (`apt-get install`):
 - apache2
-- libapach2-mod-wsgi-py3
+- libapache2-mod-wsgi-py3
 - python-pip
 - python 3.8+
 


### PR DESCRIPTION
I saw a package was missing an 'e' in the Readme file